### PR TITLE
Fix settings modal initialization error

### DIFF
--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -87,7 +87,16 @@ const settingsModalProxy = {
     async openModal() {
         console.log('Settings modal opening');
         const modalEl = document.getElementById('settingsModal');
-        const modalAD = Alpine.$data(modalEl);
+        if (!modalEl) {
+            console.error('Settings modal element not found');
+            return;
+        }
+
+        const modalAD = Alpine?.$data(modalEl);
+        if (!modalAD) {
+            console.error('Settings modal not initialised');
+            return;
+        }
 
         // First, ensure the store is updated properly
         const store = Alpine.store('root');


### PR DESCRIPTION
## Summary
- prevent crash when opening settings modal if Alpine isn't initialized yet

## Testing
- `npm run lint:clean` *(fails: Cannot find package '@eslint/js')*
- `python lint.py check` *(fails: Ruff and MyPy errors)*


------
https://chatgpt.com/codex/tasks/task_e_686cdb25aab08322a48d3fa8abe854d7