### PR TITLE
Improve mock server and settings modal

### DIFF
--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -87,7 +87,16 @@ const settingsModalProxy = {
     async openModal() {
         console.log('Settings modal opening');
         const modalEl = document.getElementById('settingsModal');
-        const modalAD = Alpine.$data(modalEl);
+        if (!modalEl) {
+            console.error('Settings modal element not found');
+            return;
+        }
+
+        const modalAD = Alpine?.$data(modalEl);
+        if (!modalAD) {
+            console.error('Settings modal not initialised');
+            return;
+        }
 
         // First, ensure the store is updated properly
         const store = Alpine.store('root');

--- a/webui/mock-server.py
+++ b/webui/mock-server.py
@@ -17,18 +17,21 @@ class MockBackendHandler(http.server.SimpleHTTPRequestHandler):
     def end_headers(self):
         """Add security headers including CSP before ending headers"""
         # Add CSP header for Alpine.js and external resources
-        self.send_header(
-            "Content-Security-Policy",
+        policy = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' cdnjs.cloudflare.com cdn.jsdelivr.net; "
-            "style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com *.googleapis.com; "
-            "font-src 'self' data: cdnjs.cloudflare.com cdn.jsdelivr.net fonts.gstatic.com *.gstatic.com; "
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' "
+            "cdnjs.cloudflare.com cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net "
+            "fonts.googleapis.com *.googleapis.com; "
+            "font-src 'self' data: cdnjs.cloudflare.com cdn.jsdelivr.net "
+            "fonts.gstatic.com *.gstatic.com; "
             "img-src 'self' data: blob: https:; "
             "connect-src 'self' ws: wss: http: https:; "
             "worker-src 'self' blob:; "
             "frame-src 'self'; "
-            "object-src 'none'",
+            "object-src 'none'"
         )
+        self.send_header("Content-Security-Policy", policy)
 
         # Add other security headers
         self.send_header("X-Frame-Options", "SAMEORIGIN")
@@ -37,7 +40,7 @@ class MockBackendHandler(http.server.SimpleHTTPRequestHandler):
 
         super().end_headers()
 
-    def do_POST(self):
+    def do_post(self):
         """Handle POST requests to API endpoints"""
         content_length = int(self.headers.get("Content-Length", 0))
         post_data = self.rfile.read(content_length)
@@ -122,7 +125,7 @@ class MockBackendHandler(http.server.SimpleHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(json.dumps(response).encode())
 
-    def do_OPTIONS(self):
+    def do_options(self):
         """Handle CORS preflight requests"""
         self.send_response(200)
         self.send_header("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
## Summary
- avoid errors if settings modal element or Alpine data missing
- shorten CSP string and use lowercase handler names in mock server

## Testing
- `npm run lint:clean` *(fails: Cannot find package '@eslint/js')*
- `python lint.py check` *(fails: 433 MyPy errors)*


------
https://chatgpt.com/codex/tasks/task_e_686cdb25aab08322a48d3fa8abe854d7

## Summary by Sourcery

Refine mock server security header and HTTP method naming, and harden settings modal initialization with element and data presence checks

Bug Fixes:
- Add null checks in settings modal to prevent errors when the modal element or Alpine data is missing

Enhancements:
- Streamline the mock server Content-Security-Policy string and consolidate header assignment
- Rename mock server HTTP handler methods to lowercase (do_post, do_options)